### PR TITLE
Create release for macOS

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: ci
+
+on: [push, pull_request]
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          components: clippy
+          override: true
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/clippy.yaml
+++ b/.github/workflows/clippy.yaml
@@ -3,11 +3,8 @@ name: ci
 on: [push, pull_request]
 
 jobs:
-  release:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  clippy:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,13 +9,21 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.os }}
+  release-linux:
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: cli/gh-extension-precompile@v1
         with:
           build_script_override: "./scripts/build.sh"
+  release-macos:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: bash ./scripts/build.sh
+      - name: Upload release artifact
+        uses: softprops/action-gh-release@v1
+        with:
+          draft: false
+          prerelease: false
+          files: dist/darwin-amd64

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   release:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
       - uses: cli/gh-extension-precompile@v1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -2,4 +2,14 @@
 
 cargo build --release --locked
 mkdir -p ./dist
-mv target/release/gh-sql ./dist/linux-amd64
+
+case "$OSTYPE" in
+    darwin*)
+        EXECUTABLE=darwin-amd64
+    ;;
+    *)
+        EXECUTABLE=linux-amd64
+    ;;
+esac
+
+mv target/release/gh-sql "./dist/$EXECUTABLE"


### PR DESCRIPTION
This PR contains two changes:

- Deploy binary for macOS on release
- Add workflow to check commits with `cargo clippy`

Here is an example release: https://github.com/rhysd/gh-sql/releases/tag/v0.0.2