### PR TITLE
Support DraftIssue

### DIFF
--- a/src/list_items.graphql
+++ b/src/list_items.graphql
@@ -49,6 +49,13 @@ query ($projectId: ID!, $after: String) {
                 }
               }
             }
+            ... on DraftIssue {
+              assignees(first: 100) {
+                nodes {
+                  login
+                }
+              }
+            }
           }
           fieldValues(first: 100) {
             nodes {


### PR DESCRIPTION
gh-sql panicked when DraftIssues are in the project (beta).
This PR solves it.

```
ghsql> select count(*) from items;
SQL execution error: Storage(Failed to parse response

Caused by:
    missing field `repository` at line 1 column 35805)
ghsql>
```